### PR TITLE
Fix logic on push/replace for falsy values

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mobx": "^6.1.7",
     "mobx-react-router": "^4.1.0",
     "mocha": "^7.1.0",
+    "prettier": "2.8.2",
     "tsup": "^5.12.1",
     "typescript": "^4.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "mocha": "^7.1.0",
     "prettier": "2.8.2",
     "tsup": "^5.12.1",
-    "typescript": "^4.6.3"
+    "typescript": "4.9.4"
   },
   "peerDependencies": {
     "history": "^4.10.1",

--- a/src/__types.ts
+++ b/src/__types.ts
@@ -9,12 +9,12 @@ export enum FalsyValue {
   'Zero',
 }
 
-export type FormatFunction = (it: any) => string
+export type FormatFunction<T> = (it: T | null | undefined) => string
 export type IRouteSetter = (url: string) => void
 export type ComputedRouteOptions<T = string> = {
   patterns: string[]
   parse?: (it: string) => T
-  format?: FormatFunction
+  format?: FormatFunction<T>
   defaultValue?: T
   keepAlive?: boolean
 }

--- a/src/__types.ts
+++ b/src/__types.ts
@@ -1,10 +1,20 @@
 import { IComputedValue } from 'mobx/dist/internal'
 
+export enum FalsyValue {
+  'EmptyString',
+  'False',
+  'NaN',
+  'Null',
+  'Undefined',
+  'Zero',
+}
+
+export type FormatFunction = (it: any) => string
 export type IRouteSetter = (url: string) => void
 export type ComputedRouteOptions<T = string> = {
   patterns: string[]
   parse?: (it: string) => T
-  format?: (it: any) => string
+  format?: FormatFunction
   defaultValue?: T
   keepAlive?: boolean
 }
@@ -12,6 +22,7 @@ export type SetRouteParamOptions = {
   enforce?: boolean
   enforcePattern?: string | undefined | null | false
   cleanParams?: boolean | ComputedRouteParam<any>[]
+  falsyValuesAllowed?: FalsyValue[]
 }
 export type ComputedRouteParam<T> = IComputedValue<T> & {
   push: RouteParamSetter<T>

--- a/src/getValueFormatted.ts
+++ b/src/getValueFormatted.ts
@@ -1,0 +1,33 @@
+import { FalsyValue, FormatFunction } from './__types'
+
+export const getValueFormatted = (value: unknown, formatFn: FormatFunction, falsyValuesAllowed: FalsyValue[]) => {
+  if (value) {
+    return formatFn(value)
+  }
+
+  if (value === '' && falsyValuesAllowed.includes(FalsyValue.EmptyString)) {
+    return formatFn(value)
+  }
+
+  if (value === false && falsyValuesAllowed.includes(FalsyValue.False)) {
+    return formatFn(value)
+  }
+
+  if (Number.isNaN(value) && falsyValuesAllowed.includes(FalsyValue.NaN)) {
+    return formatFn(value)
+  }
+
+  if (value === null && falsyValuesAllowed.includes(FalsyValue.Null)) {
+    return formatFn(value)
+  }
+
+  if (value === undefined && falsyValuesAllowed.includes(FalsyValue.Undefined)) {
+    return formatFn(value)
+  }
+
+  if (value === 0 && falsyValuesAllowed.includes(FalsyValue.Zero)) {
+    return formatFn(value)
+  }
+
+  return value
+}

--- a/src/getValueFormatted.ts
+++ b/src/getValueFormatted.ts
@@ -1,6 +1,6 @@
 import { FalsyValue, FormatFunction } from './__types'
 
-export const getValueFormatted = (value: unknown, formatFn: FormatFunction, falsyValuesAllowed: FalsyValue[]) => {
+export const getValueFormatted = <T>(value: T | null | undefined, formatFn: FormatFunction<T>, falsyValuesAllowed: FalsyValue[]) => {
   if (value) {
     return formatFn(value)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,10 +1578,10 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 v8-compile-cache-lib@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,6 +1246,11 @@ postcss-load-config@^3.0.1:
     lilconfig "^2.0.5"
     yaml "^1.10.2"
 
+prettier@2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.2.tgz#c4ea1b5b454d7c4b59966db2e06ed7eec5dfd160"
+  integrity sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==
+
 query-string@*, query-string@^6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.11.0.tgz#dc27a05733d1be66f16d0f83dfa957270f45f66d"


### PR DESCRIPTION
An interested bug is happening to me. When I call `variable.replace(0)` it doesn't work.

After some investigation, I've discovered that it's because of some logic in the `setRouteParamWith` that does not call the `format` function with falsy values.