### PR TITLE
fix: switching to mobx-react-router@5.0.0 to fix issues in mobx 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-react-router-utils",
-  "version": "4.1.4",
+  "version": "5.0.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   "devDependencies": {
     "history": "^4.10.1",
     "mobx": "^6.1.7",
-    "mobx-react-router": "^4.1.0",
+    "mobx-react-router": "^5.0.0",
     "mocha": "^7.1.0",
     "prettier": "2.8.2",
     "tsup": "^5.12.1",
@@ -47,6 +47,6 @@
   "peerDependencies": {
     "history": "^4.10.1",
     "mobx": "^5.15.4",
-    "mobx-react-router": "^4.1.0"
+    "mobx-react-router": "^5.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,10 +1022,10 @@ mkdirp@0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mobx-react-router@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/mobx-react-router/-/mobx-react-router-4.1.0.tgz#de014848207d8aa32f6a4e67ed861bd2cb6516e5"
-  integrity sha512-2knsbDqVorWLngZWbdO8tr7xcZXaLpVFsFlCaGaoyZ+EP9erVGRxnlWGqKyFObs3EH1JPLyTDOJ2LPTxb/lB6Q==
+mobx-react-router@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/mobx-react-router/-/mobx-react-router-5.0.0.tgz#846879b3ee004c96aa4eddd255802a4242a90d27"
+  integrity sha512-JO336+DVaTnshQtl1j1reEHaNHgeGpdfSmTlx8VA/cwIC6Dk5mEMk4gvW0yPruFdUJJVmA2I/7yZo4J7BeVe9Q==
 
 mobx@^6.1.7:
   version "6.3.0"


### PR DESCRIPTION
+ bumping version to 5.0.0 to keep it in sync with mobx-react-router (5.0.0), we can still publish versions 4.x.x for mobx 5 that we still need to support
