### PR TITLE
Using matchers also for queryParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-react-router-utils",
-  "version": "4.1.4",
+  "version": "4.2.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/getComputedRouteParams.ts
+++ b/src/getComputedRouteParams.ts
@@ -12,7 +12,7 @@ export const getComputedRouteParams = memoize((routePatterns: string[]) => {
 
   return computed(() => {
     let pathParams = {}
-    let queryParams = parseQueryString(getRoutingStore().location.search)
+    let queryParams = {}
 
     for (let match of matchers) {
       let matchResult: false | { params: any } = match(
@@ -21,6 +21,7 @@ export const getComputedRouteParams = memoize((routePatterns: string[]) => {
       if (matchResult === false) continue
 
       pathParams = matchResult.params
+      queryParams = parseQueryString(getRoutingStore().location.search)
     }
 
     const pathParamsIsEmpty = Object.keys(pathParams).length === 0


### PR DESCRIPTION
With the current implementation, `computedRoutePrams` are firing updates / reactions from query params even if we are already on another url (not matching pattern). This is a bug IMHO.